### PR TITLE
fix: dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# .dockerignore
+.git
+.github
+.gradle
+gradle
+gradlew*
+*.md
+README.md
+src/main
+src/test
+.gitignore
+.env
+logs
+scripts
+application.yml
+deploy.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM openjdk:11-jdk
+FROM openjdk:11-jre-slim
 ARG JAR_FILE=build/libs/webfounder-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} /webfounder.jar
 EXPOSE 8080


### PR DESCRIPTION
  1. Dockerfile: openjdk:11-jdk → openjdk:11-jre-slim (더 가벼운 이미지)
  2. .dockerignore 추가: 불필요한 파일들을 Docker 빌드에서 제외하여 빌드 컨텍스트 크기 대폭 감소