### PR TITLE
Fix: GoogleDocsConfig Credential 경로 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build/resources/main/credentials.json
 src/main/resources/application.yml
 /build/
 /.gradle/.env
+/.gradle
+/.idea

--- a/src/main/java/com/smlikelion/webfounder/global/config/GoogleDocsConfig.java
+++ b/src/main/java/com/smlikelion/webfounder/global/config/GoogleDocsConfig.java
@@ -1,5 +1,8 @@
 package com.smlikelion.webfounder.global.config;
 
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.docs.v1.Docs;
 import com.google.api.services.docs.v1.DocsScopes;
 import com.google.api.services.docs.v1.model.*;
@@ -13,7 +16,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 
-import java.io.IOException;
+import java.io.*;
+import java.security.GeneralSecurityException;
 import java.util.Collections;
 
 @Slf4j
@@ -21,17 +25,38 @@ import java.util.Collections;
 public class GoogleDocsConfig {
 
     @Bean
-    public Docs docsService() throws IOException {
-        GoogleCredentials credentials = GoogleCredentials.fromStream(
-                        new java.io.FileInputStream("/app/credentials.json")
-                )
-                .createScoped(Collections.singleton(DocsScopes.DOCUMENTS));
+    public Docs docsService() throws IOException, GeneralSecurityException {
+        InputStream credentialsStream = getCredentialsStream();
+
+        GoogleCredentials credentials = GoogleCredentials
+                .fromStream(credentialsStream)
+                .createScoped(Collections.singletonList(DocsScopes.DOCUMENTS));
+
+        HttpRequestInitializer requestInitializer = new HttpCredentialsAdapter(credentials);
 
         return new Docs.Builder(
-                new NetHttpTransport(),
-                JacksonFactory.getDefaultInstance(),
-                new HttpCredentialsAdapter(credentials))
-                .setApplicationName("Recruitment System")
+                GoogleNetHttpTransport.newTrustedTransport(),
+                GsonFactory.getDefaultInstance(),
+                requestInitializer)
+                .setApplicationName("Webfounder")
                 .build();
+    }
+
+    private InputStream getCredentialsStream() throws FileNotFoundException {
+        // 1. EC2 환경: /app/credentials.json 파일 확인
+        File prodFile = new File("/app/credentials.json");
+        if (prodFile.exists()) {
+            return new FileInputStream(prodFile);
+        }
+
+        // 2. 로컬 환경: classpath의 credentials.json 사용
+        InputStream resourceStream = getClass().getClassLoader()
+                .getResourceAsStream("credentials.json");
+
+        if (resourceStream != null) {
+            return resourceStream;
+        }
+
+        throw new FileNotFoundException("credentials.json 파일을 찾을 수 없습니다.");
     }
 }


### PR DESCRIPTION
## credentials.json 경로 위치가 바뀌었던 이유: 
- EC2에서는 스프링부트 백엔드가 .jar로 배포되었기 때문에 crendentials.json을 jar 파일과 같은 경로에 두어야 했음 
- 따라서 credentials.json이 /app/credentials.json 경로에 있었음

## 수정 사항
- 환경에 따라 credentials.json을 찾는 방식을 다르게 함:
    - EC2 환경일 경우 /app/credentials.json
    - 로컬일경우: ```.getResourceAsStream("credentials.json")```으로 credentials.json을 찾음

