### PR TITLE
fix: return HTTP 409 only for duplicate recruitment

### DIFF
--- a/src/main/java/com/smlikelion/webfounder/Recruit/Controller/RecruitController.java
+++ b/src/main/java/com/smlikelion/webfounder/Recruit/Controller/RecruitController.java
@@ -55,14 +55,18 @@ public class RecruitController {
                 return ResponseEntity.status(HttpStatus.CONFLICT).body(new BaseResponse<>(ErrorCode.DUPLICATE_STUDENT_ID_ERROR));
             } catch (Exception e) {
                 log.error("Google Docs 업로드 중 오류 발생", e);
-                return ResponseEntity .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                        .body(new BaseResponse<>(ErrorCode.INTERNAL_SERVER_ERROR.getCode(),"Google docs update failed", null));
+
+                BaseResponse<RecruitmentResponse> response = new BaseResponse<>(ErrorCode.INTERNAL_SERVER_ERROR);
+                response.setMessage("Google docs update failed");
+
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
             }
         } else {
             // 유효하지 않은 트랙 값 처리
-            String errorMessage = "Invalid track value. Please provide a valid track (fe, pm, be).";
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(new BaseResponse<>(ErrorCode.UNSUPPORTED_TRACK_ERROR.getCode(), errorMessage, null));
+            BaseResponse<RecruitmentResponse> response = new BaseResponse<>(ErrorCode.UNSUPPORTED_TRACK_ERROR);
+            response.setMessage("Invalid track value. Please provide a valid track (fe, pm, be).");
+
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
         }
     }
 


### PR DESCRIPTION
### 수정 사항 내용

- 기존  
 BaseResponse를 활용하여 모든 응답의 http status가 200으로 내려가면서 내부 response data의 code로 예외들이 판별 가능한 구조

- 수정 후
controller의 반환 타입을 response entity로 확장하였고 response data의 status code와 실제 내려가는 http status code를 일치 시켰습니다.

<img width="1036" height="323" alt="image" src="https://github.com/user-attachments/assets/e23796b1-d795-4af8-9640-25c37075ce2c" />
<img width="912" height="299" alt="image" src="https://github.com/user-attachments/assets/ec8df7d6-fdee-4f71-af21-9143908c348d" />
<img width="1030" height="299" alt="image" src="https://github.com/user-attachments/assets/754fc740-9ce4-4e0f-b2af-d48fd4e81c17" />


